### PR TITLE
Remove CrossOrigin annotation from LoginController

### DIFF
--- a/src/main/java/com/revature/rideforce/user/controllers/LoginController.java
+++ b/src/main/java/com/revature/rideforce/user/controllers/LoginController.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -20,7 +19,6 @@ import com.revature.rideforce.user.services.UserService;
 
 @RestController
 @RequestMapping("/login")
-@CrossOrigin
 public class LoginController {
 	@Autowired
 	private UserService userService;


### PR DESCRIPTION
The gateway service takes care of adding CORS headers appropriately; doing it again in the user service results in a duplicate header.