### PR TITLE
Fix CORS redirect issue by returning user object on GET /login

### DIFF
--- a/src/main/java/com/revature/rideforce/user/controllers/LoginController.java
+++ b/src/main/java/com/revature/rideforce/user/controllers/LoginController.java
@@ -29,7 +29,7 @@ public class LoginController {
 	public ResponseEntity<?> getCurrentUser() {
 		User currentUser = authenticationService.getCurrentUser();
 		return currentUser == null ? new ResponseError("Not logged in.").toResponseEntity(HttpStatus.FORBIDDEN)
-				: ResponseEntity.status(HttpStatus.FOUND).location(currentUser.toUri()).build();
+				: ResponseEntity.ok(currentUser);
 	}
 
 	@PostMapping(consumes = MediaType.APPLICATION_JSON_UTF8_VALUE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)


### PR DESCRIPTION
Firefox does not correctly handle preflighted CORS requests resulting from a redirect (e.g. HTTP status 302); this works around that issue.