### PR TITLE
Fix user endpoint permissions for matching service

### DIFF
--- a/src/main/java/com/revature/rideforce/user/security/WebSecurityConfig.java
+++ b/src/main/java/com/revature/rideforce/user/security/WebSecurityConfig.java
@@ -22,9 +22,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 	protected void configure(HttpSecurity http) throws Exception {
 		// Matchers for routes that can be accessed without authentication.
 		RequestMatcher[] allowable = { new AntPathRequestMatcher("/login", "POST"),
-				new AntPathRequestMatcher("/users", "POST"), new AntPathRequestMatcher("/offices", "GET"),
-				new AntPathRequestMatcher("/contact-types", "GET"), new AntPathRequestMatcher("/roles", "GET"),
-				new AntPathRequestMatcher("/**", "OPTIONS") };
+				new AntPathRequestMatcher("/users", "GET"), new AntPathRequestMatcher("/users", "POST"),
+				new AntPathRequestMatcher("/offices", "GET"), new AntPathRequestMatcher("/contact-types", "GET"),
+				new AntPathRequestMatcher("/roles", "GET"), new AntPathRequestMatcher("/**", "OPTIONS") };
 
 		http.csrf().disable();
 		http.authorizeRequests().requestMatchers(allowable).permitAll().anyRequest().authenticated();

--- a/src/main/java/com/revature/rideforce/user/services/UserService.java
+++ b/src/main/java/com/revature/rideforce/user/services/UserService.java
@@ -65,6 +65,13 @@ public class UserService extends CrudService<User> {
 	}
 	
 	@Override
+	protected boolean canFindAll(User user) {
+		// This is not ideal, but needs to be this way until the matching
+		// service can pass along authorization headers.
+		return true;
+	}
+	
+	@Override
 	protected boolean canAdd(User user, User obj) {
 		// Make sure users can't add other users with elevated permissions.
 		if (obj.isAdmin() || obj.isTrainer()) {


### PR DESCRIPTION
The matching service needs to be able to access the `/users` endpoint, and doesn't yet pass along authorization tokens.