### PR TITLE
Bio length & Test Clean Up

### DIFF
--- a/src/main/java/com/revature/rideforce/user/beans/User.java
+++ b/src/main/java/com/revature/rideforce/user/beans/User.java
@@ -84,8 +84,8 @@ public class User implements UserDetails, Identifiable, Linkable, Serializable {
 	@Size(max = 200)
 	private String photoUrl;
 
-	@Column(length = 200)
-	@Size(max = 200)
+	@Column
+	@Size(max = 255)
 	private String bio;
 
 	private boolean active = true; //default 

--- a/src/test/java/com/revature/beanTests/ContactInfoTest.java
+++ b/src/test/java/com/revature/beanTests/ContactInfoTest.java
@@ -54,8 +54,11 @@ public class ContactInfoTest {
 	
 	@Test
 	public void testViolationWithInvalidIdOnContactInfo() {
-		ContactInfo contactInfo = new ContactInfo(0, new User(),
-				new ContactType(), "info");
+		ContactInfo contactInfo = new ContactInfo();
+		contactInfo.setId(0);
+		contactInfo.setUser(new User());
+		contactInfo.setType(new ContactType());
+		contactInfo.setInfo("info");
 		Set<ConstraintViolation<ContactInfo>> violations = localValidatorFactory.validate(contactInfo);
 		int counter = 0;
 		
@@ -72,8 +75,11 @@ public class ContactInfoTest {
 	
 	@Test
 	public void testViolationWithInvalidUser() {
-		ContactInfo contactInfo = new ContactInfo(0, null,
-				new ContactType(), "info");
+		ContactInfo contactInfo = new ContactInfo();
+		contactInfo.setId(0);
+		contactInfo.setUser(null);
+		contactInfo.setType(new ContactType());
+		contactInfo.setInfo("info");
 		Set<ConstraintViolation<ContactInfo>> violations = localValidatorFactory.validate(contactInfo);
 		int counter = 0;
 		
@@ -90,8 +96,11 @@ public class ContactInfoTest {
 	
 	@Test
 	public void testViolationWithInvalidContactType() {
-		ContactInfo contactInfo = new ContactInfo(0, new User(),
-				null, "info");
+		ContactInfo contactInfo = new ContactInfo();
+		contactInfo.setId(0);
+		contactInfo.setUser(new User());
+		contactInfo.setType(null);
+		contactInfo.setInfo("info");
 		Set<ConstraintViolation<ContactInfo>> violations = localValidatorFactory.validate(contactInfo);
 		int counter = 0;
 		
@@ -108,8 +117,11 @@ public class ContactInfoTest {
 	
 	@Test
 	public void testViolationWithEmptyInfo() {
-		ContactInfo contactInfo = new ContactInfo(0, new User(),
-				new ContactType(), "");
+		ContactInfo contactInfo = new ContactInfo();
+		contactInfo.setId(0);
+		contactInfo.setUser(new User());
+		contactInfo.setType(new ContactType());
+		contactInfo.setInfo("");
 		Set<ConstraintViolation<ContactInfo>> violations = localValidatorFactory.validate(contactInfo);
 		int counter = 0;
 		

--- a/src/test/java/com/revature/beanTests/ContactInfoTest.java
+++ b/src/test/java/com/revature/beanTests/ContactInfoTest.java
@@ -1,23 +1,18 @@
 package com.revature.beanTests;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
 
 import org.assertj.core.api.Assertions;
 import org.hibernate.validator.HibernateValidator;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
-import com.revature.rideforce.user.beans.Car;
 import com.revature.rideforce.user.beans.ContactInfo;
 import com.revature.rideforce.user.beans.ContactType;
-import com.revature.rideforce.user.beans.Office;
 import com.revature.rideforce.user.beans.User;
-import com.revature.rideforce.user.beans.UserRole;
 
 public class ContactInfoTest {
 	

--- a/src/test/java/com/revature/repositoryTests/ContactInfoRepositoryTest.java
+++ b/src/test/java/com/revature/repositoryTests/ContactInfoRepositoryTest.java
@@ -1,7 +1,5 @@
 package com.revature.repositoryTests;
 
-import java.util.List;
-
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,6 +14,7 @@ import com.revature.rideforce.user.beans.ContactInfo;
 import com.revature.rideforce.user.beans.ContactType;
 import com.revature.rideforce.user.beans.User;
 import com.revature.rideforce.user.repository.ContactInfoRepository;
+import com.revature.rideforce.user.repository.ContactTypeRepository;
 import com.revature.rideforce.user.repository.UserRepository;
 
 @RunWith(SpringRunner.class)

--- a/src/test/java/com/revature/repositoryTests/ContactInfoRepositoryTest.java
+++ b/src/test/java/com/revature/repositoryTests/ContactInfoRepositoryTest.java
@@ -14,7 +14,6 @@ import com.revature.rideforce.user.beans.ContactInfo;
 import com.revature.rideforce.user.beans.ContactType;
 import com.revature.rideforce.user.beans.User;
 import com.revature.rideforce.user.repository.ContactInfoRepository;
-import com.revature.rideforce.user.repository.ContactTypeRepository;
 import com.revature.rideforce.user.repository.UserRepository;
 
 @RunWith(SpringRunner.class)

--- a/src/test/java/com/revature/serviceTests/AuthenticationServiceTest.java
+++ b/src/test/java/com/revature/serviceTests/AuthenticationServiceTest.java
@@ -6,13 +6,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.revature.rideforce.user.UserApplication;
-import com.revature.rideforce.user.beans.User;
 import com.revature.rideforce.user.beans.UserCredentials;
-import com.revature.rideforce.user.beans.UserRegistrationInfo;
 import com.revature.rideforce.user.exceptions.EntityConflictException;
 import com.revature.rideforce.user.exceptions.InvalidCredentialsException;
 import com.revature.rideforce.user.exceptions.InvalidRegistrationKeyException;

--- a/src/test/java/com/revature/serviceTests/AuthenticationServiceTest.java
+++ b/src/test/java/com/revature/serviceTests/AuthenticationServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 


### PR DESCRIPTION
Updated bio to have max size 255. Accommodated for removal of ContactInfo constructor in tests. Removed unused imports in several tests.