### PR TITLE
Password reset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,15 @@
 		    <groupId>org.hibernate</groupId>
 		    <artifactId>hibernate-validator</artifactId>
 		    <version>6.0.13.Final</version>
-		</dependency>			
+		</dependency>	
+		
+		<!-- https://mvnrepository.com/artifact/javax.mail/mail -->
+		<dependency>
+		    <groupId>javax.mail</groupId>
+		    <artifactId>mail</artifactId>
+		    <version>1.5.0-b01</version>
+		</dependency>
+				
 
 	</dependencies>
 

--- a/src/main/java/com/revature/rideforce/user/UserApplication.java
+++ b/src/main/java/com/revature/rideforce/user/UserApplication.java
@@ -95,7 +95,7 @@ public class UserApplication implements InitializingBean {
 			admin.setContactInfo(new HashSet<>());
 			admin.setActive("ACTIVE");
 			admin.setRole(userRoleRepository.findByTypeIgnoreCase(ADMIN));
-			admin.setPassword(passwordEncoder.encode("password"));
+			admin.setPassword("password"); 							//within setPassword is where we can encode it (more modular)
 			admin.setStartTime(Time.valueOf("09:00:00"));
 			userRepository.save(admin);
 		}

--- a/src/main/java/com/revature/rideforce/user/beans/User.java
+++ b/src/main/java/com/revature/rideforce/user/beans/User.java
@@ -30,14 +30,18 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import com.revature.rideforce.user.exceptions.EmptyPasswordException;
 import com.revature.rideforce.user.json.CarLinkResolver;
 import com.revature.rideforce.user.json.ContactInfoLinkResolver;
 import com.revature.rideforce.user.json.JsonEnumLike;
@@ -45,6 +49,7 @@ import com.revature.rideforce.user.json.JsonLink;
 import com.revature.rideforce.user.json.Linkable;
 import com.revature.rideforce.user.json.OfficeLinkResolver;
 import com.revature.rideforce.user.json.UserRoleResolver;
+import com.revature.rideforce.user.security.PasswordSecurityUtil;
 
 /**
 
@@ -182,8 +187,11 @@ public class User implements UserDetails, Identifiable, Linkable, Serializable {
 		return password;
 	}
 
-	public void setPassword(String password) {
-		this.password = password;
+	public void setPassword(String password) throws EmptyPasswordException { 
+		//changing the place to encode because this is more modular than encoding in the Application.class, updateUser controller view, and loginrecovery reset password view
+		if(password.equals(""))
+			throw new EmptyPasswordException();
+		this.password = PasswordSecurityUtil.getPasswordEncoder().encode(password); //made the class because as a member of User, gave me errors in LoginRecoveryControllerTest...null pointer exceptions, idk
 	}
 
 	public String getPhotoUrl() {

--- a/src/main/java/com/revature/rideforce/user/beans/changeModels/ChangeUserModel.java
+++ b/src/main/java/com/revature/rideforce/user/beans/changeModels/ChangeUserModel.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import com.revature.rideforce.user.beans.Office;
 import com.revature.rideforce.user.beans.User;
 import com.revature.rideforce.user.beans.UserRole;
+import com.revature.rideforce.user.exceptions.EmptyPasswordException;
 
 public class ChangeUserModel {
 
@@ -146,7 +147,11 @@ public class ChangeUserModel {
 		if(active != null)
 			original.setActive(active);
 		if(password != null)
-			original.setPassword(password);
+			try {
+				original.setPassword(password);
+			} catch (EmptyPasswordException e) {
+				//don't change the password if it's empty ""
+			}
 		if(startTime != null)
 			original.setStartTime(startTime);
 	}

--- a/src/main/java/com/revature/rideforce/user/beans/changeModels/LoginRecoveryProcessForm.java
+++ b/src/main/java/com/revature/rideforce/user/beans/changeModels/LoginRecoveryProcessForm.java
@@ -1,0 +1,66 @@
+package com.revature.rideforce.user.beans.changeModels;
+
+/**
+ * Just holds the String token and String new password to be processed in put {@linkplain LoginRecoveryController}
+ * @author clpeng
+ * @since Iteration 2 10/20/2018
+ */
+public class LoginRecoveryProcessForm {
+	private String token;
+	private String newPassword;
+	public LoginRecoveryProcessForm() {
+		super();
+	}
+	public LoginRecoveryProcessForm(String token, String newPassword) {
+		super();
+		this.token = token;
+		this.newPassword = newPassword;
+	}
+	public String getToken() {
+		return token;
+	}
+	public String getNewPassword() {
+		return newPassword;
+	}
+	public void setToken(String token) {
+		this.token = token;
+	}
+	public void setNewPassword(String newPassword) {
+		this.newPassword = newPassword;
+	}
+	@Override
+	public String toString() {
+		return "LoginRecoveryProcessForm [token=" + token + ", newPassword=" + newPassword + "]";
+	}
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((newPassword == null) ? 0 : newPassword.hashCode());
+		result = prime * result + ((token == null) ? 0 : token.hashCode());
+		return result;
+	}
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		LoginRecoveryProcessForm other = (LoginRecoveryProcessForm) obj;
+		if (newPassword == null) {
+			if (other.newPassword != null)
+				return false;
+		} else if (!newPassword.equals(other.newPassword))
+			return false;
+		if (token == null) {
+			if (other.token != null)
+				return false;
+		} else if (!token.equals(other.token))
+			return false;
+		return true;
+	}
+	
+	
+}

--- a/src/main/java/com/revature/rideforce/user/controllers/LoginController.java
+++ b/src/main/java/com/revature/rideforce/user/controllers/LoginController.java
@@ -41,4 +41,5 @@ public class LoginController {
 			return new ResponseError(e).toResponseEntity(HttpStatus.FORBIDDEN);
 		}
 	}
+	
 }

--- a/src/main/java/com/revature/rideforce/user/controllers/LoginRecoveryController.java
+++ b/src/main/java/com/revature/rideforce/user/controllers/LoginRecoveryController.java
@@ -1,0 +1,101 @@
+package com.revature.rideforce.user.controllers;
+
+import javax.ws.rs.core.MediaType;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.revature.rideforce.user.beans.User;
+import com.revature.rideforce.user.beans.changeModels.LoginRecoveryProcessForm;
+import com.revature.rideforce.user.exceptions.EmptyPasswordException;
+import com.revature.rideforce.user.exceptions.EntityConflictException;
+import com.revature.rideforce.user.exceptions.PermissionDeniedException;
+import com.revature.rideforce.user.security.LoginRecoveryTokenProvider;
+import com.revature.rideforce.user.services.SendEmailService;
+import com.revature.rideforce.user.services.UserService;
+
+@RestController("/recovery")
+@CrossOrigin
+public class LoginRecoveryController {  							//once tests work, make the token stored in the data base
+																	//and add a new service? that uses userRepo under a token
+	@Autowired
+	private UserService userService;
+	@Autowired
+	private LoginRecoveryTokenProvider loginRecoveryTokenProvider;
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+	
+	@PostMapping(consumes= "application/json", produces = MediaType.APPLICATION_JSON)
+	public User postSendEmail(@RequestBody String email) throws PermissionDeniedException
+	{
+		//find the user by email and rtn
+		User user = userService.findByEmail(email);
+		if(user != null)  //if user, send an email
+		{
+			//need to make a token 
+			//don't have to really "remember" the token or save it anywhere. The details of the token lie within its string.
+			String token = loginRecoveryTokenProvider.generateToken(user.getId());    
+			SendEmailService.sendLoginRecoveryEmail(token, email);
+		} //if user != null
+		
+		return user; //will be null if no match. They can say if null that no email was sent and they dont have a record of it
+	}
+	
+	//add a method to authentication service
+	//need another controller view for clicking that link (2nd). Should verify the token is still good. Then angular has form
+	//then on submit, will need 3rd view to receive form and save new password into db
+	/**
+	 * 
+	 * @param token <code>String</code> representing the token that will be part of the viewpoint url
+	 * @return <code>int</code> id of the user account to help recover password
+	 */
+																			//For ANGULAR --> https://stackoverflow.com/questions/45997369/how-to-get-param-from-url-in-angular-4/45998138
+	@GetMapping(params="token", produces = "application/json")  				 //email link will take to angular's page with path parameter ? token	
+	//made wrapper return cuz can be null
+	public Integer processResetPasswordToken(@RequestParam("token") String token)  //angular can make GET request here with the token and we return which 
+	{																			//userId account to process
+		return this.loginRecoveryTokenProvider.checkTokenForUser(token);        //if userId null, should redirect back to login or p/w reset failed page
+	}
+	
+	
+	
+	@PutMapping( produces = "application/json") 				//this handles after the angular form is submitted with new p/w
+																				//do the check for non null p/w, confirmed p/w same, to pass us just 1 string
+	public User processResetPasswordRequest(@RequestBody LoginRecoveryProcessForm tokenAndNewPassword)
+	{
+		//hopefully newPassword that's passed in from angular fits constraints
+		Integer id = loginRecoveryTokenProvider.checkTokenForUser(tokenAndNewPassword.getToken());
+		
+		if(id == null) 
+			return null;   //token has expired,   when Angular receives null, should redirect to a Sorry, please make a new request page
+		
+		try {
+			User user = userService.findById(id);
+			if(user != null) 
+			{
+				user.setPassword(tokenAndNewPassword.getNewPassword());  //if "" password, will throw then in catch, rtn null w/o saving user
+				userService.save(user);
+			}
+			
+			return user;
+		} catch (PermissionDeniedException e) {     //for findbyid, if no user is "logged in"
+			return null;
+		} catch (EntityConflictException e) { 		//if during save() the newPassword makes the User object identical to another
+			return null;
+		} catch (EmptyPasswordException e) {
+			return null;
+		} 
+	}
+	
+}

--- a/src/main/java/com/revature/rideforce/user/controllers/RegistrationKeyController.java
+++ b/src/main/java/com/revature/rideforce/user/controllers/RegistrationKeyController.java
@@ -22,6 +22,11 @@ public class RegistrationKeyController {
 	@Autowired
 	private AuthenticationService authenticationService;
 
+	/**
+	 * the link where you can get a registration token. Only admins and trainers should be able to generate the token for 
+	 * someone to register
+	 * @return <code>String</code> from {@linkplain RegistrationTokenProvider#generateToken()}
+	 */
 	@RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<?> get() {
 		// Only trainers and admins can get registration tokens.

--- a/src/main/java/com/revature/rideforce/user/controllers/UserController.java
+++ b/src/main/java/com/revature/rideforce/user/controllers/UserController.java
@@ -23,6 +23,7 @@ import com.revature.rideforce.user.beans.User;
 import com.revature.rideforce.user.beans.UserRegistrationInfo;
 import com.revature.rideforce.user.beans.UserRole;
 import com.revature.rideforce.user.beans.changeModels.ChangeUserModel;
+import com.revature.rideforce.user.exceptions.EmptyPasswordException;
 import com.revature.rideforce.user.exceptions.EntityConflictException;
 import com.revature.rideforce.user.exceptions.InvalidRegistrationKeyException;
 import com.revature.rideforce.user.exceptions.PermissionDeniedException;
@@ -115,6 +116,8 @@ public class UserController {
 			return new ResponseError(e).toResponseEntity(HttpStatus.FORBIDDEN);
 		} catch (EntityConflictException e) {
 			return new ResponseError(e).toResponseEntity(HttpStatus.CONFLICT);
+		} catch (EmptyPasswordException e) {
+			return new ResponseError(e).toResponseEntity(HttpStatus.LENGTH_REQUIRED);
 		}
 	}
 

--- a/src/main/java/com/revature/rideforce/user/exceptions/EmptyPasswordException.java
+++ b/src/main/java/com/revature/rideforce/user/exceptions/EmptyPasswordException.java
@@ -1,0 +1,9 @@
+package com.revature.rideforce.user.exceptions;
+
+public class EmptyPasswordException extends Exception{
+	private static final long serialVersionUID = 1L;
+
+	public EmptyPasswordException() {
+		super("Can not set user's password to an empty password");
+	}
+}

--- a/src/main/java/com/revature/rideforce/user/security/LoginRecoveryTokenProvider.java
+++ b/src/main/java/com/revature/rideforce/user/security/LoginRecoveryTokenProvider.java
@@ -1,0 +1,40 @@
+package com.revature.rideforce.user.security;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.revature.rideforce.user.services.UserService;
+
+/**
+ * use in AuthenticationService to make the specific login recovery token
+ * @author clpeng
+ *
+ */
+@Service  																
+public class LoginRecoveryTokenProvider extends JwtProvider{
+	//similar to the registration token
+	
+	//subject to pass into JwtProvider's generateToken(subject, duration)
+//	public static final String SUBJECT_RECOVERY = "RECOVERY";
+	
+	public String generateToken(Integer id)
+	{
+		//make a token for recovery. User can reset password within 30 min, and token information/subject is just the user Id
+		return super.generateToken(String.valueOf(id), Duration.ofMinutes(30)); //could use "this" instead of super, but super is more readable
+	}
+	
+	/**
+	 * use this method when you want to see the token later and validate it didnt expire/is a real token with valid subject
+	 * @return <code>int</code> representing the User id we're gonna have password recovery for
+	 */
+	public Integer checkTokenForUser(String token) {
+		//using JwtProvider's getSubject(), which returns null for expired or invalid tokens. JwtProvider is an abstract class we made that uses some of
+		//built in Spring Security stuff
+		return ( ( super.getSubject(token) ) != null ? Integer.parseInt( super.getSubject(token) ) : null );
+		//I can't rtn a user because i'd have to be logged in xD	
+		
+	}
+	
+}

--- a/src/main/java/com/revature/rideforce/user/security/PasswordSecurityConfig.java
+++ b/src/main/java/com/revature/rideforce/user/security/PasswordSecurityConfig.java
@@ -6,7 +6,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 /**
- * configures password by encoding it
+ * dependency for PasswordEncoder uses BCryptPasswordEncoder
  * @author clpeng
  * @since Iteration1 10/01/2018
  *

--- a/src/main/java/com/revature/rideforce/user/security/PasswordSecurityUtil.java
+++ b/src/main/java/com/revature/rideforce/user/security/PasswordSecurityUtil.java
@@ -1,0 +1,18 @@
+package com.revature.rideforce.user.security;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class PasswordSecurityUtil {
+	private static PasswordEncoder passwordEncoder;
+	
+	private PasswordSecurityUtil() {}
+	public static PasswordEncoder getPasswordEncoder()
+	{
+		if(PasswordSecurityUtil.passwordEncoder == null)
+			PasswordSecurityUtil.passwordEncoder = new BCryptPasswordEncoder();
+		return PasswordSecurityUtil.passwordEncoder;
+	}
+	
+	
+}

--- a/src/main/java/com/revature/rideforce/user/services/AuthenticationService.java
+++ b/src/main/java/com/revature/rideforce/user/services/AuthenticationService.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import com.revature.rideforce.user.beans.User;
 import com.revature.rideforce.user.beans.UserCredentials;
 import com.revature.rideforce.user.beans.UserRegistrationInfo;
+import com.revature.rideforce.user.exceptions.EmptyPasswordException;
 import com.revature.rideforce.user.exceptions.EntityConflictException;
 import com.revature.rideforce.user.exceptions.InvalidCredentialsException;
 import com.revature.rideforce.user.exceptions.InvalidRegistrationKeyException;
@@ -77,13 +78,14 @@ public class AuthenticationService {
 	 *                                         desired user (e.g. if an
 	 *                                         unauthenticated user attempts to
 	 *                                         create an admin)
+	 * @throws EmptyPasswordException          Password in the {@linkplain UserRegistrationInfo} must be non empty
 	 */
 	public User register(UserRegistrationInfo info)
-			throws InvalidRegistrationKeyException, EntityConflictException, PermissionDeniedException {
+			throws InvalidRegistrationKeyException, EntityConflictException, PermissionDeniedException, EmptyPasswordException {
 		if(info == null) {
 			throw new InvalidRegistrationKeyException();
 		}
-		// Make sure that the registration key is valid.
+		// Make sure that the registration key token is valid.
 		if (!registrationTokenProvider.isValid(info.getRegistrationKey())) {
 			log.info("Attempting to register user");
 			log.debug(info.getRegistrationKey());
@@ -91,10 +93,7 @@ public class AuthenticationService {
 		}
 		log.info("User registered successfully");
 		log.info("Hashing password");
-		String passwordHash = passwordEncoder.encode(info.getPassword());
-		log.info("passwordHash: {}", passwordHash);
-
-		info.getUser().setPassword(passwordHash);
+		info.getUser().setPassword(info.getPassword());   //hashing will be done in setPassword()
 		return userService.add(info.getUser());
 	}
 

--- a/src/main/java/com/revature/rideforce/user/services/SendEmailService.java
+++ b/src/main/java/com/revature/rideforce/user/services/SendEmailService.java
@@ -1,0 +1,65 @@
+package com.revature.rideforce.user.services;
+
+import java.util.Properties;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+/**
+ * for the LoginRecoveryController for modularizing sending the email
+ * @author clpeng
+ * @since Iteration 2 10/20/2018
+ */
+public class SendEmailService {
+
+	final static int GMAIL_SMTP_PORT = 587;
+	/**
+	 * send an email with a link to the front end's reset password page with a token in the url parameter. Sender email is specified within the method 
+	 * instead of in the parameters
+	 * @param token <code>String</code> needed for building the password reset link
+	 * @param receiver the email to send message to
+	 */
+	public static void sendLoginRecoveryEmail(String token, String receiver)
+	{
+		//will need a link..."website.com/[token]" 
+//		https://www.javatpoint.com/example-of-sending-html-content-with-email-using-java-mail-api
+		//https://kinsta.com/knowledgebase/free-smtp-server/
+		//https://myaccount.google.com/lesssecureapps     <----Go here and turn it on so gmail doesnt block this app's access to the account
+		String sender = "smtp.gmail.com"; 		
+		String username = "rideforce.reset@gmail.com";     //dummy email: birthday - 01/01/1996; gender - rather not say; 
+		String password = "revaturecode123";
+		String url = "http://whateverthefrontendendpointislol.com";
+		
+		Properties properties = System.getProperties();  //import java.util for "Properties"
+		properties.setProperty("mail.smtp.host", sender);  
+		properties.put("mail.smtp.auth", "true");  
+		properties.put("mail.smtp.port", GMAIL_SMTP_PORT); //465  	//these last two lines, the port for ttls is 587, and you gotta enable ttls first to use 587
+		properties.put("mail.smtp.starttls.enable", true);
+		
+		Session session = Session.getDefaultInstance(properties,     					//Session and MimeMessage from javax.mail
+			    new javax.mail.Authenticator() {  
+			     protected PasswordAuthentication getPasswordAuthentication() {  
+			      return new PasswordAuthentication(username, password);  
+			     }  
+		});  
+		
+		MimeMessage message = new MimeMessage(session);
+		try {
+			message.setFrom(new InternetAddress(sender));
+			message.setRecipient(Message.RecipientType.TO, new InternetAddress(receiver));
+			
+			message.setSubject("Password Reset Link from RevatureRideForce");
+			message.setContent("<a href= "+"'"+url+"?token="+token+"'>Click here to reset password</a>", "text/html");
+			
+			Transport.send(message);
+			
+		} catch (MessagingException e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   datasource:
     url: ${JDBC_URL}
     username: ${JDBC_USERNAME}
-    password: ${JDBC_PASSWORD}
+    password: ${JDBC_PASSWORD}         #INSTEAD, CAN JUST ADD ENV VARIABLES    SPRING_DATASOURCE_URL/USERNAME/PASSWORD
     driver-class-name: oracle.jdbc.driver.OracleDriver
   jpa:
     hibernate:

--- a/src/test/java/com/revature/beanTests/UserTest.java
+++ b/src/test/java/com/revature/beanTests/UserTest.java
@@ -10,13 +10,15 @@ import org.assertj.core.api.Assertions;
 import org.hibernate.validator.HibernateValidator;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 import com.revature.rideforce.user.beans.Car;
 import com.revature.rideforce.user.beans.ContactInfo;
 import com.revature.rideforce.user.beans.Office;
 import com.revature.rideforce.user.beans.User;
-import com.revature.rideforce.user.beans.UserRole;
+import com.revature.rideforce.user.exceptions.EmptyPasswordException;
 
 public class UserTest {
 
@@ -25,7 +27,7 @@ public class UserTest {
 	private User u;
 
 	@Before
-    public void setupValidatorFactory () {
+    public void setupValidatorFactory () throws EmptyPasswordException {
         localValidatorFactory = new LocalValidatorFactoryBean();
         localValidatorFactory.setProviderClass(HibernateValidator.class);
         localValidatorFactory.afterPropertiesSet();
@@ -114,18 +116,17 @@ public class UserTest {
 		Assertions.assertThat(counter).isEqualTo(1);
 	}
 	
-	@Test
-	public void emptyUserPasswordTest() {
+	@Test(expected = EmptyPasswordException.class)
+	public void emptyUserPasswordTest() throws EmptyPasswordException {
 		u.setPassword("");
-		Set<ConstraintViolation<User>> violations = localValidatorFactory.validate(u);
-		int counter = 0;
-		
-		for(ConstraintViolation<User> v: violations) {
-			if (!v.getPropertyPath().toString().contains(".")) {
-				counter++;
-			}
-		}
-		Assertions.assertThat(counter).isEqualTo(1);
+//		Set<ConstraintViolation<User>> violations = localValidatorFactory.validate(u);
+//		int counter = 0;
+//		for(ConstraintViolation<User> v: violations) {
+//			if (!v.getPropertyPath().toString().contains(".")) {
+//				counter++;
+//			}
+//		}
+//		Assertions.assertThat(counter).isEqualTo(1);
 	}
 	
 	@Test

--- a/src/test/java/com/revature/controllerTests/LoginRecoveryControllerTest.java
+++ b/src/test/java/com/revature/controllerTests/LoginRecoveryControllerTest.java
@@ -1,0 +1,162 @@
+package com.revature.controllerTests;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.UnsupportedEncodingException;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.revature.rideforce.user.UserApplication;
+import com.revature.rideforce.user.beans.User;
+import com.revature.rideforce.user.beans.changeModels.LoginRecoveryProcessForm;
+import com.revature.rideforce.user.exceptions.PermissionDeniedException;
+import com.revature.rideforce.user.repository.UserRepository;
+import com.revature.rideforce.user.security.LoginRecoveryTokenProvider;
+import com.revature.rideforce.user.services.UserService;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = UserApplication.class)
+@AutoConfigureMockMvc
+public class LoginRecoveryControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private UserService userService;
+	@Autowired
+	private LoginRecoveryTokenProvider loginRecoveryTokenProvider;
+	@Autowired
+	private UserRepository userRepository;
+	
+	private ObjectMapper objectMapper;
+	private String adminsRecoveryToken;
+	private User temp;							//test email: "rideforce.reset@gmail.com", password: "revaturecode123" 
+	private static final String TEST_EMAIL = "rideforce.reset@gmail.com"; 			//can replace with the email you have access to
+	private static final String NOT_IN_DB_EMAIL = "c@boo.com";
+	
+	@Before
+	public void setUp() throws PermissionDeniedException 
+	{
+		temp = userRepository.findById(1);   
+		temp.setEmail(TEST_EMAIL);
+		
+		this.adminsRecoveryToken = loginRecoveryTokenProvider.generateToken(1);
+		this.objectMapper = new ObjectMapper();
+		
+		Assertions.assertThat(objectMapper).isNotNull();
+		Assertions.assertThat(adminsRecoveryToken).isNotNull();
+		Assertions.assertThat(temp).isNotNull();
+		Assertions.assertThat(userRepository).isNotNull();
+		Assertions.assertThat(userService).isNotNull();
+		Assertions.assertThat(loginRecoveryTokenProvider).isNotNull();
+		Assertions.assertThat(mockMvc).isNotNull();
+	}
+	
+	@Test
+	@Transactional
+	public void postSendEmailFoundUserTest() throws Exception
+	{
+		userRepository.save(this.temp);  //just temporarily making admin's email the test email so it sends to an email we can check
+		
+		Authentication auth = new UsernamePasswordAuthenticationToken(temp, "", temp.getAuthorities()); 	//FIXME this is problem. The endpoint inaccessible less logged in
+		SecurityContextHolder.getContext().setAuthentication(auth);  										//gotta make endpt under WebCofiguration accessible w/o login, just with a token
+		
+		String jsonResponseBody = this.mockMvc.perform(post("/recovery").contentType("application/json").content(TEST_EMAIL))
+									.andExpect(status().is2xxSuccessful())
+									.andReturn().getResponse().getContentAsString();
+		Assertions.assertThat(jsonResponseBody).contains(TEST_EMAIL);      //json body contains information different from the User object
+																			//because of the json link resolver... so just gonna see if it's not null is all
+		SecurityContextHolder.getContext().setAuthentication(null); 
+	}
+	
+	@Test 											//tbh, no way to check if an email unsuccessfully sent, it's just there's no "admin@revature.com" email
+	public void postSendEmailNonexistentEmailShouldReturnNullUserAndNotSendEmailTest() throws Exception
+	{
+		Authentication auth = new UsernamePasswordAuthenticationToken(temp, "", temp.getAuthorities()); 	//FIXME this is problem. The endpoint inaccessible less logged in
+		SecurityContextHolder.getContext().setAuthentication(auth);  										//gotta make endpt under WebCofiguration accessible w/o login, just with a token
+		
+		String jsonResponseBody = this.mockMvc.perform(post("/recovery").contentType("application/json").content(NOT_IN_DB_EMAIL))
+									.andExpect(status().is2xxSuccessful())
+									.andReturn().getResponse().getContentAsString();
+	
+		Assertions.assertThat(jsonResponseBody).isEmpty();             //The User returned should be null, not found   
+		SecurityContextHolder.getContext().setAuthentication(null); 
+	}
+	
+	@Test
+	public void processResetPasswordTokenGoodTokenTest() throws UnsupportedEncodingException, Exception
+	{
+		Authentication auth = new UsernamePasswordAuthenticationToken(temp, "", temp.getAuthorities()); 	//FIXME this is problem. The endpoint inaccessible less logged in
+		SecurityContextHolder.getContext().setAuthentication(auth);  										//gotta make endpt under WebCofiguration accessible w/o login, just with a token
+		
+		String token = this.adminsRecoveryToken;
+		String responseBody = this.mockMvc.perform(get("/recovery?token="+token)).andExpect(status().isOk())
+																				 .andReturn().getResponse().getContentAsString();
+		Assertions.assertThat(responseBody).isEqualTo("1");
+		SecurityContextHolder.getContext().setAuthentication(null); 
+	}
+	
+	
+	@Test
+	public void processResetPasswordTokenBadTokenTest() throws UnsupportedEncodingException, Exception
+	{
+		Authentication auth = new UsernamePasswordAuthenticationToken(temp, "", temp.getAuthorities()); 	//FIXME this is problem. The endpoint inaccessible less logged in
+		SecurityContextHolder.getContext().setAuthentication(auth);  										//gotta make endpt under WebCofiguration accessible w/o login, just with a token
+		
+		String token = "badtoken";
+		String responseBody = this.mockMvc.perform(get("/recovery?token="+token)).andExpect(status().isOk())
+																				 .andReturn().getResponse().getContentAsString();
+		Assertions.assertThat(responseBody).isEmpty();
+		SecurityContextHolder.getContext().setAuthentication(null); 
+	}
+	
+	
+	//https://stackoverflow.com/questions/20504399/testing-springs-requestbody-using-spring-mockmvc
+	@Transactional
+	@Test
+	public void processResetPasswordRequestTest() throws UnsupportedEncodingException, Exception
+	{
+		//FIXME gotta make endpt under WebCofiguration accessible w/o login, just with a token
+		SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(temp, "", temp.getAuthorities()));				
+		
+		//to set content of requestbody, gotta turn into json string first
+		String requestBody =  this.objectMapper.writeValueAsString( new LoginRecoveryProcessForm(this.adminsRecoveryToken, "password2") );
+		
+		String responseBody = this.mockMvc.perform(put("/recovery").contentType("application/json").content(requestBody))
+											.andExpect(status().isOk())
+											.andReturn().getResponse().getContentAsString();
+		Assertions.assertThat(responseBody).contains("id", "admin", "lastName"); //vs contains "" would be null response body
+
+		SecurityContextHolder.getContext().setAuthentication(null); 
+	}
+	
+	@Test
+	public void processResetPasswordRequestBadTokenShouldGiveNullTest() throws UnsupportedEncodingException, Exception
+	{
+		SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(temp, "", temp.getAuthorities()));	
+		
+		String requestBody =  this.objectMapper.writeValueAsString( new LoginRecoveryProcessForm("badtoken", "password2") );
+		String responseBody = this.mockMvc.perform(put("/recovery").contentType("application/json").content(requestBody))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+		Assertions.assertThat(responseBody).isEmpty(); //vs contains "" would be null response body
+
+		SecurityContextHolder.getContext().setAuthentication(null); 
+	}
+}

--- a/src/test/java/com/revature/serviceTests/AuthenticationServiceTest.java
+++ b/src/test/java/com/revature/serviceTests/AuthenticationServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.revature.rideforce.user.UserApplication;
 import com.revature.rideforce.user.beans.UserCredentials;
+import com.revature.rideforce.user.exceptions.EmptyPasswordException;
 import com.revature.rideforce.user.exceptions.EntityConflictException;
 import com.revature.rideforce.user.exceptions.InvalidCredentialsException;
 import com.revature.rideforce.user.exceptions.InvalidRegistrationKeyException;
@@ -44,7 +45,7 @@ public class AuthenticationServiceTest {
 	}
 	
 	@Test(expected = InvalidRegistrationKeyException.class)
-	public void registerWithInvalidRegistrationInfoThrowsException() throws InvalidRegistrationKeyException, EntityConflictException, PermissionDeniedException {
+	public void registerWithInvalidRegistrationInfoThrowsException() throws InvalidRegistrationKeyException, EntityConflictException, PermissionDeniedException, EmptyPasswordException {
 		authenticationService.register(null);
 	}
 	

--- a/src/test/java/com/revature/serviceTests/AuthenticationServiceUnitTest.java
+++ b/src/test/java/com/revature/serviceTests/AuthenticationServiceUnitTest.java
@@ -21,6 +21,7 @@ import com.revature.rideforce.user.UserApplication;
 import com.revature.rideforce.user.beans.User;
 import com.revature.rideforce.user.beans.UserCredentials;
 import com.revature.rideforce.user.beans.UserRegistrationInfo;
+import com.revature.rideforce.user.exceptions.EmptyPasswordException;
 import com.revature.rideforce.user.exceptions.EntityConflictException;
 import com.revature.rideforce.user.exceptions.InvalidCredentialsException;
 import com.revature.rideforce.user.exceptions.InvalidRegistrationKeyException;
@@ -67,11 +68,11 @@ public class AuthenticationServiceUnitTest {
 	}
 	
 	@Before
-	public void setUpMockitos() throws EntityConflictException, PermissionDeniedException
+	public void setUpMockitos() throws EntityConflictException, PermissionDeniedException, EmptyPasswordException
 	{
 		User user = new User();
 		user.setEmail("admin@revature.com");
-		user.setPassword(passwordEncoder.encode("password"));
+		user.setPassword("password");
 		Mockito.when(userRepo.findByEmail("admin@revature.com")).thenReturn(user);
 		
 		Mockito.when( userService.add(any()) ).then( i -> i.getArgument(0) ); //return the user it was given
@@ -109,7 +110,7 @@ public class AuthenticationServiceUnitTest {
 	}
 	
 	@Test
-	public void registerTest() throws InvalidRegistrationKeyException, EntityConflictException, PermissionDeniedException
+	public void registerTest() throws InvalidRegistrationKeyException, EntityConflictException, PermissionDeniedException, EmptyPasswordException
 	{
 		String token = registrationTokenProvider.generateToken();
 		registrationInfo = new UserRegistrationInfo(this.user, "pally", token);
@@ -125,14 +126,14 @@ public class AuthenticationServiceUnitTest {
 	}
 	
 	@Test(expected = NullPointerException.class)
-	public void registerWithNullPasswordTest() throws InvalidRegistrationKeyException, EntityConflictException, PermissionDeniedException
+	public void registerWithNullPasswordTest() throws InvalidRegistrationKeyException, EntityConflictException, PermissionDeniedException, EmptyPasswordException
 	{
 		registrationInfo = new UserRegistrationInfo(null, null, registrationTokenProvider.generateToken());
 		authenticationService.register(registrationInfo);
 	}
 
 	@Test
-	public void getCurrentUserTest()
+	public void getCurrentUserTest() throws EmptyPasswordException
 	{
 		//when no session, getCurrentUser should return nulll
 		Assertions.assertThat(authenticationService.getCurrentUser()).isNull();

--- a/src/test/java/com/revature/serviceTests/SendEmailServiceTest.java
+++ b/src/test/java/com/revature/serviceTests/SendEmailServiceTest.java
@@ -1,0 +1,20 @@
+package com.revature.serviceTests;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.revature.rideforce.user.UserApplication;
+import com.revature.rideforce.user.security.LoginRecoveryTokenProvider;
+import com.revature.rideforce.user.services.SendEmailService;
+
+public class SendEmailServiceTest {
+	@Test
+	public void sendLoginRecoveryEmailWorksTest()  
+													//this is not really a test, just wanted to have a place where I can run the method
+	{ 												//then I just check my email
+		SendEmailService.sendLoginRecoveryEmail("token_here", "clpeng@ucdavis.edu");
+	}
+}


### PR DESCRIPTION
 added a way to reset the password, but it's not complete. I think we have to add the rest in another pull though because this one still feels like a lot. It's not complete because the endpoint can't be accessed atm unless the person is logged in (see WebConfigurations class in security pkg), so I'm not sure but we probably want either another filter (like JwtFilter ) that'll take in the token and have user permissions for just the page like in https://www.baeldung.com/spring-security-registration-i-forgot-my-password
 " 
      Authentication auth = new UsernamePasswordAuthenticationToken(
      user, null, Arrays.asList(
      new SimpleGrantedAuthority("CHANGE_PASSWORD_PRIVILEGE")));
"
Either that or add it to WebConfigurations as one of the paths not needing the authentication, and then in the endpoints of LoginRecoveryController, return null right away after checking the token?

Also have to save the password as the token subject (instead of user id) so we can make it more of a one time link (check the token's subject password compare to current password and if different (db password will be updated after they click submit) then the token won't be valid anymore

can check the email using credentials for the dummy email "rideforce.reset@gmail.com" and "revaturecode123" 